### PR TITLE
test (currently failing) that shows different behavior when using afterburner

### DIFF
--- a/src/test/java/com/fasterxml/jackson/module/afterburner/deser/TestSimpleDeserialize.java
+++ b/src/test/java/com/fasterxml/jackson/module/afterburner/deser/TestSimpleDeserialize.java
@@ -88,6 +88,17 @@ public class TestSimpleDeserialize extends AfterburnerTestBase
         public void setString(String s) { stringMethod = s; }
         public void setEnum(MyEnum e) { enumMethod = e; }
     }
+
+    static class BeanWithNonVoidPropertyGetter {
+        private String stringField;
+
+        public String getStringField() { return stringField; }
+
+        public BeanWithNonVoidPropertyGetter setStringField(String username) {
+            this.stringField = username;
+            return this;
+        }
+    }
     
     /*
     /**********************************************************************
@@ -200,5 +211,17 @@ public class TestSimpleDeserialize extends AfterburnerTestBase
         assertEquals(11L, bean.longMethod);
         assertEquals(MyEnum.A, bean.enumField);
         assertEquals(MyEnum.B, bean.enumMethod);
+    }
+
+    public void testNonVoidProperty() throws Exception
+    {
+        ObjectMapper mapper = new ObjectMapper();
+        String json = "{ \"stringField\" : \"zoobar\" }";
+        BeanWithNonVoidPropertyGetter bean = mapper.readValue(json, BeanWithNonVoidPropertyGetter.class);
+        assertEquals("zoobar", bean.getStringField());
+        mapper = mapperWithModule(); // if I don't do this, the module won't be picked up
+        // current fails with java.lang.NoSuchMethodError
+        bean = mapper.readValue(json, BeanWithNonVoidPropertyGetter.class);
+        assertEquals("zoobar", bean.getStringField());
     }
 }


### PR DESCRIPTION
Properties that have a setting that is non-void are recognized by Jackson (1.x as well as 2.x) but not when afterburner is installed.
